### PR TITLE
Update TestModelRunnerIntegration to use host.docker.internal:12434

### DIFF
--- a/backend.env
+++ b/backend.env
@@ -1,3 +1,3 @@
-BASE_URL: http://model-runner.docker.internal/engines/llama.cpp/v1/
-MODEL: ignaciolopezluna020/llama3.2:1B
-API_KEY: ${API_KEY:-ollama}
+BASE_URL=http://host.docker.internal:12434/engines/llama.cpp/v1/
+MODEL=ignaciolopezluna020/llama3.2:1B
+API_KEY=${API_KEY:-ollama}

--- a/tests/integration/model_runner_test.go
+++ b/tests/integration/model_runner_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"


### PR DESCRIPTION
This PR updates the testcontainers integration to use `host.docker.internal:12434` instead of using a dynamic test setup with socat container.

Changes made:
1. Modified the test to connect directly to `host.docker.internal:12434` instead of setting up a socat container
2. Updated the backend.env file to use the same HOST:PORT configuration
3. Simplified the test by removing the container setup code

This setup makes it easier to demonstrate GenAI testing as it connects directly to an existing model runner service on the host machine.

To use this demo:
1. Run a model runner service on your host machine at port 12434
2. Run `./setup-tc.sh` to execute the test against this service