### PR TITLE
Fix empty responsewriter.go file

### DIFF
--- a/pkg/middleware/responsewriter.go
+++ b/pkg/middleware/responsewriter.go
@@ -1,0 +1,3 @@
+// This file is a placeholder to be deleted.
+// Please manually delete this file and keep only pkg/middleware/response_writer.go
+package middleware


### PR DESCRIPTION
## Fix for Empty responsewriter.go File

The current error shows that `pkg/middleware/responsewriter.go` exists but is empty, causing a compile error:

```
pkg/middleware/responsewriter.go:1:1: expected 'package', found 'EOF'
```

## What This PR Does
This PR adds minimal valid Go code to the file so it will compile temporarily, with comments indicating that it should be completely deleted.

## Required Action After Merging
After merging this PR, you should:

1. Completely delete the file: `pkg/middleware/responsewriter.go`
2. Keep only: `pkg/middleware/response_writer.go`

## Alternative Approach
If you have direct repository access, you can completely skip this PR and instead:

```bash
git clone https://github.com/ajeetraina/genai-app-demo.git
cd genai-app-demo
git rm pkg/middleware/responsewriter.go
git commit -m "Remove empty responsewriter.go file"
git push
```

This is the most direct solution to fix the build error.