### PR TITLE
Add Docker Model Runner support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# LLM Model configuration
+LLM_MODEL_NAME=llama3:latest
+
+# API Key for model service
+API_KEY=dockermodelrunner

--- a/README-model-runner.md
+++ b/README-model-runner.md
@@ -1,0 +1,51 @@
+# Using Docker Model Runner with genai-app-demo
+
+This branch adds support for Docker Compose's built-in model runner functionality, introduced in Docker Compose v2.35.0.
+
+## Prerequisites
+
+- Docker Desktop with Compose v2.35.0 or later
+- Docker Desktop extension for Model Runner installed
+
+## How it Works
+
+The updated `compose.yaml` file includes a new `llm` service that uses the model provider:
+
+```yaml
+llm:
+  provider:
+    type: model
+    options:
+      model: ${LLM_MODEL_NAME:-llama3:latest}
+```
+
+This allows the backend service to connect to the LLM service using the hostname `llm` on port 11434.
+
+## Configuration
+
+You can configure the model to use by setting the `LLM_MODEL_NAME` environment variable in the `.env` file. 
+
+Supported models include:
+- `llama3:latest` (default)
+- `llama3:8b`
+- `llama3:70b`
+- Other models available in the Docker Model Runner
+
+## Running the Application
+
+```bash
+# Start all services
+docker compose up -d
+
+# Check the logs
+docker compose logs -f backend
+```
+
+## Accessing the Model Service Directly
+
+The model service is accessible to containers at hostname `llm` on port 11434.
+
+The API follows the Ollama API format, so you can make requests to:
+- `http://llm:11434/api/generate` - For text generation
+- `http://llm:11434/api/chat` - For chat completions
+- `http://llm:11434/api/embeddings` - For generating embeddings

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,8 @@ services:
       retries: 3
     networks:
       - app-network
+    depends_on:
+      - llm
 
   frontend:
     build:
@@ -67,6 +69,13 @@ services:
       - '4318:4318'    # OTLP HTTP
     networks:
       - app-network
+
+  # New LLM service using Docker Compose's model provider
+  llm:
+    provider:
+      type: model
+      options:
+        model: ${LLM_MODEL_NAME:-llama3:latest}
 
 volumes:
   grafana-data:


### PR DESCRIPTION
## Add support for Docker Model Runner

This PR adds support for Docker Compose's built-in model runner functionality, introduced in Docker Compose v2.35.0.

### Changes:
- Added new `llm` service to `compose.yaml` using the model provider
- Added `.env` file with model configuration
- Created documentation on how to use the model runner
- Updated backend service to depend on the llm service

### How to use:
1. Ensure you have Docker Desktop with Compose v2.35.0 or later
2. Make sure the Docker Desktop extension for Model Runner is installed
3. Run `docker compose up -d`
4. The backend will connect to the LLM service using the hostname `llm`

### Configuration:
The model can be configured by setting the `LLM_MODEL_NAME` environment variable in the `.env` file:
```
LLM_MODEL_NAME=llama3:latest
```

Supported models include:
- `llama3:latest` (default)
- `llama3:8b`
- `llama3:70b`
- Other models available in the Docker Model Runner