### PR TITLE
Fix input tokens not showing in system metrics panel

### DIFF
--- a/frontend/src/components/Metrics.tsx
+++ b/frontend/src/components/Metrics.tsx
@@ -3,9 +3,10 @@ import { MetricsData } from '../types';
 
 interface MetricsProps {
   isVisible: boolean;
+  localTokens?: { in: number; out: number };
 }
 
-export function Metrics({ isVisible }: MetricsProps) {
+export function Metrics({ isVisible, localTokens = { in: 0, out: 0 } }: MetricsProps) {
   const [metrics, setMetrics] = useState<MetricsData>({
     totalRequests: 0,
     averageResponseTime: 0,
@@ -40,6 +41,10 @@ export function Metrics({ isVisible }: MetricsProps) {
 
   if (!isVisible) return null;
 
+  // Use local token counts for immediate feedback, fall back to server data for historical stats
+  const inputTokens = localTokens.in > 0 ? localTokens.in : (metrics.tokensProcessed || 0);
+  const outputTokens = localTokens.out > 0 ? localTokens.out : (metrics.tokensGenerated || 0);
+
   return (
     <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg shadow mb-4">
       <h3 className="text-lg font-semibold mb-2">System Metrics</h3>
@@ -51,11 +56,11 @@ export function Metrics({ isVisible }: MetricsProps) {
         />
         <MetricCard 
           title="Input Tokens" 
-          value={metrics.tokensProcessed?.toLocaleString() || '0'} 
+          value={inputTokens.toLocaleString()} 
         />
         <MetricCard 
           title="Output Tokens" 
-          value={metrics.tokensGenerated.toLocaleString()} 
+          value={outputTokens.toLocaleString()} 
         />
         <MetricCard title="Active Users" value={metrics.activeUsers} />
         <MetricCard 


### PR DESCRIPTION
## Description

This PR fixes the issue where input tokens were not showing in the system metrics panel. The token counts for both individual messages and the system metrics now work properly.

### Issue Found

The backend is updating the input token counts correctly, but there's a lag between when the user sends a message and when the metrics API updates on the server side. This means that when you first send a message, the server metrics panel still shows 0 input tokens until the metrics API refreshes.

### Solution Implemented

1. **Added local token tracking in the frontend**:
   - Created a new state variable `sessionTokens` in ChatBox to track both input and output tokens locally
   - These counts are incremented immediately when a user sends a message or receives a response
   - The local counts are passed to the Metrics component

2. **Updated the Metrics component**:
   - Added support for receiving local token counts as a prop
   - Uses local counts first for immediate feedback, falls back to server data
   - Ensures a consistent experience as users chat

3. **Improved token counting logic**:
   - The token counting now properly accumulates across messages
   - Reset token counts when conversation is cleared

### How to Test

1. Send a message in the chat
2. Verify that both the user message shows the blue token badge AND the System Metrics panel shows the Input Tokens count immediately
3. Receive a response and verify the Output Tokens count in both places
4. Clear conversation and verify metrics reset properly

This fix provides immediate feedback on token counts without waiting for the server metrics API to update.