### PR TITLE
Fix: Implement markdown formatting for chat output

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,11 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-markdown": "^9.0.2",
+    "rehype-highlight": "^7.0.0",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,3 +44,72 @@ body {
     animation: fadeIn 0.3s ease-out forwards;
   }
 }
+
+/* Markdown Styling */
+.markdown-content {
+  @apply text-gray-800 dark:text-gray-200;
+}
+
+.markdown-content h1 {
+  @apply text-xl font-bold my-4;
+}
+
+.markdown-content h2 {
+  @apply text-lg font-bold my-3;
+}
+
+.markdown-content h3 {
+  @apply text-base font-bold my-2;
+}
+
+.markdown-content h4, .markdown-content h5, .markdown-content h6 {
+  @apply font-bold my-2;
+}
+
+.markdown-content p {
+  @apply my-2;
+}
+
+.markdown-content ul {
+  @apply list-disc pl-6 my-2;
+}
+
+.markdown-content ol {
+  @apply list-decimal pl-6 my-2;
+}
+
+.markdown-content li {
+  @apply my-1;
+}
+
+.markdown-content blockquote {
+  @apply border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic my-3;
+}
+
+.markdown-content hr {
+  @apply my-4 border-gray-300 dark:border-gray-700;
+}
+
+.markdown-content img {
+  @apply max-w-full my-2 rounded;
+}
+
+.markdown-content pre {
+  @apply rounded overflow-auto p-3 my-3 bg-gray-800 dark:bg-gray-900 text-white dark:text-gray-200;
+}
+
+.markdown-content code {
+  @apply font-mono;
+}
+
+.markdown-content table {
+  @apply w-full border-collapse my-3;
+}
+
+.markdown-content th {
+  @apply border border-gray-300 dark:border-gray-700 px-4 py-2 bg-gray-100 dark:bg-gray-800;
+}
+
+.markdown-content td {
+  @apply border border-gray-300 dark:border-gray-700 px-4 py-2;
+}

--- a/frontend/src/components/MessageItem.tsx
+++ b/frontend/src/components/MessageItem.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { Message } from '../types';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeHighlight from 'rehype-highlight';
 
 interface MessageItemProps {
   message: Message;
@@ -27,12 +31,85 @@ export const MessageItem: React.FC<MessageItemProps> = ({ message, showTokenCoun
       )}
       <div className="flex flex-col max-w-[75%]">
         <div
-          className={`p-3 rounded-lg whitespace-pre-wrap ${isUser
+          className={`p-3 rounded-lg ${isUser
             ? 'bg-blue-500 text-white rounded-tr-none'
             : 'bg-gray-100 dark:bg-gray-800 dark:text-white rounded-tl-none'
           }`}
         >
-          {message.content}
+          {isUser ? (
+            <div className="whitespace-pre-wrap">{message.content}</div>
+          ) : (
+            <div className="markdown-content">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw, rehypeHighlight]}
+                components={{
+                  // Customize code blocks
+                  code({ node, inline, className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || '');
+                    return !inline && match ? (
+                      <pre className={`bg-gray-900 dark:bg-gray-950 rounded p-2 my-2 overflow-x-auto`}>
+                        <code className={`language-${match[1]}`} {...props}>
+                          {children}
+                        </code>
+                      </pre>
+                    ) : (
+                      <code className="bg-gray-200 dark:bg-gray-700 px-1 rounded" {...props}>
+                        {children}
+                      </code>
+                    );
+                  },
+                  // Customize links
+                  a({ node, children, href, ...props }) {
+                    return (
+                      <a
+                        href={href}
+                        className="text-blue-400 hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        {...props}
+                      >
+                        {children}
+                      </a>
+                    );
+                  },
+                  // Customize tables
+                  table({ node, children, ...props }) {
+                    return (
+                      <div className="overflow-x-auto my-2">
+                        <table className="border-collapse w-full" {...props}>
+                          {children}
+                        </table>
+                      </div>
+                    );
+                  },
+                  thead({ node, children, ...props }) {
+                    return (
+                      <thead className="bg-gray-200 dark:bg-gray-700" {...props}>
+                        {children}
+                      </thead>
+                    );
+                  },
+                  th({ node, children, ...props }) {
+                    return (
+                      <th className="border border-gray-300 dark:border-gray-600 p-2 text-left" {...props}>
+                        {children}
+                      </th>
+                    );
+                  },
+                  td({ node, children, ...props }) {
+                    return (
+                      <td className="border border-gray-300 dark:border-gray-600 p-2" {...props}>
+                        {children}
+                      </td>
+                    );
+                  }
+                }}
+              >
+                {message.content}
+              </ReactMarkdown>
+            </div>
+          )}
         </div>
         <div className={`text-xs mt-1 ${isUser ? 'text-right' : 'text-left'} flex items-center ${isUser ? 'justify-end' : 'justify-start'}`}>
           <span className="text-gray-500">{timestamp}</span>


### PR DESCRIPTION
## Overview
This PR resolves issue #36 by implementing markdown formatting support for chat responses.

### Changes
1. Added React Markdown package and related dependencies to properly render formatted text
2. Updated the MessageItem component to render assistant responses with markdown formatting
3. Added CSS styling for markdown content to ensure proper display of headings, lists, code blocks, etc.
4. Modified the backend to optionally format responses using markdown

### How to Use
The chat will now render assistant responses using markdown formatting. This enhances the display of:
- Headings
- Lists (ordered and unordered)
- Code blocks with syntax highlighting
- Tables
- Links
- And other standard markdown elements

The backend will automatically use markdown formatting if the user message contains phrases like "in markdown" or "using markdown". You can also explicitly request markdown by setting the format parameter in the request.

### Screenshots
Before:
![Before](https://private-user-images.githubusercontent.com/46484439/436512141-1784037e-7f7e-4934-b92e-683a8872d546.png)

After (similar to Claude's output):
![After](https://private-user-images.githubusercontent.com/46484439/436512403-7882547b-96fd-4ae9-b265-261262a43617.png)

Closes #36
