### PR TITLE
Fix: Implement markdown formatting for chat output

### DIFF
--- a/frontend/src/components/SimplifiedMetrics.tsx
+++ b/frontend/src/components/SimplifiedMetrics.tsx
@@ -112,7 +112,15 @@ export function SimplifiedMetrics({ isVisible, messages }: SimplifiedMetricsProp
       </div>
       
       <div className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-        Direct token calculation (4 chars = 1 token)
+        <p>Direct token calculation (4 chars = 1 token)</p>
+        <a 
+          href="http://localhost:3001" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          className="mt-2 inline-block underline hover:text-blue-500"
+        >
+          View detailed metrics dashboard
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Overview
This PR resolves issue #36 by implementing markdown formatting support for chat responses.

### Changes
1. Added React Markdown package and related dependencies to properly render formatted text
2. Updated the MessageItem component to render assistant responses with markdown formatting
3. Added CSS styling for markdown content to ensure proper display of headings, lists, code blocks, etc.
4. Modified the backend to optionally format responses using markdown
5. **Added back the Grafana metrics dashboard link** that was missing in the updated SimplifiedMetrics component

### How to Use
The chat will now render assistant responses using markdown formatting. This enhances the display of:
- Headings
- Lists (ordered and unordered)
- Code blocks with syntax highlighting
- Tables
- Links
- And other standard markdown elements

The backend will automatically use markdown formatting if the user message contains phrases like "in markdown" or "using markdown". You can also explicitly request markdown by setting the format parameter in the request.

### Screenshots
Before:
![Before](https://private-user-images.githubusercontent.com/46484439/436512141-1784037e-7f7e-4934-b92e-683a8872d546.png)

After (similar to Claude's output):
![After](https://private-user-images.githubusercontent.com/46484439/436512403-7882547b-96fd-4ae9-b265-261262a43617.png)

Closes #36