### PR TITLE
Fix: Dynamic model name in chat title and footer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,14 +2,19 @@ import { useState, useEffect } from 'react';
 import './App.css';
 import ChatBox from './components/ChatBox.tsx';
 import { Header } from './components/Header.tsx';
+import { ModelMetadata } from './types';
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
+  const [modelInfo, setModelInfo] = useState<ModelMetadata | null>(null);
 
   useEffect(() => {
     // Check for user preference
     const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     setDarkMode(isDark);
+    
+    // Fetch model information
+    fetchModelInfo();
   }, []);
 
   useEffect(() => {
@@ -20,8 +25,56 @@ function App() {
     }
   }, [darkMode]);
 
+  const fetchModelInfo = async () => {
+    try {
+      const response = await fetch('http://localhost:8080/health');
+      if (response.ok) {
+        const data = await response.json();
+        if (data.model_info) {
+          setModelInfo(data.model_info);
+        }
+      }
+    } catch (e) {
+      console.error('Failed to fetch model info:', e);
+    }
+  };
+
   const toggleDarkMode = () => {
     setDarkMode(!darkMode);
+  };
+
+  // Format the model name for display
+  const getModelDisplayInfo = () => {
+    if (!modelInfo || !modelInfo.model) {
+      return "AI Model";  // Default fallback
+    }
+    
+    let modelName = modelInfo.model;
+    let modelSize = "";
+    
+    // Try to extract size information (like 1B, 7B, etc.)
+    const sizeMatch = modelName.match(/[:\-](\d+[bB])/);
+    if (sizeMatch && sizeMatch[1]) {
+      modelSize = `(${sizeMatch[1].toUpperCase()})`;
+    }
+    
+    // Extract base model name
+    if (modelName.includes('/')) {
+      modelName = modelName.split('/').pop() || modelName;
+    }
+    
+    if (modelName.includes(':')) {
+      modelName = modelName.split(':')[0];
+    }
+    
+    // Clean up common model name formats
+    modelName = modelName
+      .replace(/\.(\d)/g, ' $1')  // Add space before version numbers
+      .replace(/([a-z])(\d)/gi, '$1 $2')  // Add space between letters and numbers
+      .replace(/llama/i, 'Llama')  // Capitalize model names
+      .replace(/smollm/i, 'SmolLM');
+    
+    return `${modelName} ${modelSize}`;
   };
 
   return (
@@ -31,7 +84,7 @@ function App() {
         <ChatBox />
       </div>
       <footer className="text-center p-4 text-sm text-gray-500 dark:text-gray-400">
-        <p>Powered by <span className="font-semibold">Docker Model Runner</span> running <span className="font-semibold">Llama 3.2 (1B)</span> in a Docker container</p>
+        <p>Powered by <span className="font-semibold">Docker Model Runner</span> running <span className="font-semibold">{getModelDisplayInfo()}</span> in a Docker container</p>
       </footer>
     </div>
   );

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -244,11 +244,41 @@ export default function ChatBox() {
     setShowMetrics(!showMetrics);
   };
 
+  // Get the model name for display
+  const getModelDisplayName = () => {
+    if (!modelInfo || !modelInfo.model) {
+      return "AI Assistant";  // Default fallback
+    }
+    
+    // Clean up model name for display (e.g., "ai/llama3.2:1b" becomes "Llama 3.2")
+    let displayName = modelInfo.model;
+    
+    // Extract the model name from potential paths or prefixes
+    if (displayName.includes('/')) {
+      displayName = displayName.split('/').pop() || displayName;
+    }
+    
+    // Remove version tags if present
+    if (displayName.includes(':')) {
+      displayName = displayName.split(':')[0];
+    }
+    
+    // Clean up common model name formats
+    displayName = displayName
+      .replace(/\.(\d)/g, ' $1')  // Add space before version numbers
+      .replace(/([a-z])(\d)/gi, '$1 $2')  // Add space between letters and numbers
+      .replace(/llama/i, 'Llama')  // Capitalize model names
+      .replace(/smollm/i, 'SmolLM');
+    
+    // Return the cleaned model name
+    return displayName;
+  };
+
   return (
     <div className="flex flex-col w-full max-w-3xl mx-auto h-[calc(100vh-180px)] rounded-lg shadow-lg border dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden transition-colors duration-200">
       <div className="flex items-center justify-between p-4 border-b dark:border-gray-800">
         <div className="flex items-center space-x-2">
-          <h2 className="text-lg font-semibold">Chat with Llama 3.2</h2>
+          <h2 className="text-lg font-semibold">Chat with {getModelDisplayName()}</h2>
           {modelInfo && (
             <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">
               {modelInfo.model}


### PR DESCRIPTION
## Overview
This PR resolves issue #35 by making the chat title and footer dynamically display the correct model name instead of hardcoding "Llama 3.2".

### Changes
1. Modified the ChatBox component to dynamically display the model name in the header:
   - Added a `getModelDisplayName()` function that extracts and formats the model name from the `modelInfo` object
   - Replaced the hardcoded "Chat with Llama 3.2" title with "Chat with {getModelDisplayName()}"

2. Updated the App component to use dynamic model information in the footer:
   - Added model info fetching in the App component
   - Created a `getModelDisplayInfo()` function to format the model name
   - Updated the footer text to show the actual model name and size instead of hardcoded "Llama 3.2 (1B)"

### How it Works
- The app fetches model information from the backend's `/health` endpoint
- Model names are parsed and formatted for better display (e.g., "ai/llama3.2:1b" becomes "Llama 3.2 (1B)")
- Special handling for different model name formats, with proper spacing and capitalization
- Fallback to generic names if model information isn't available

### Screenshots
Before:
![Before](https://private-user-images.githubusercontent.com/46484439/436508952-4e990a29-7f9a-41ab-9e8b-464b52d8d43c.png)

After (example with SmolLM):
![After](https://private-user-images.githubusercontent.com/46484439/436509280-97c336c1-aa00-4109-9520-dea781e99224.png)

Closes #35